### PR TITLE
vispy 0.16.1 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,11 @@ requirements:
 
 # E   ModuleNotFoundError: No module named 'meshio'
 {% set deselect_tests = " --deselect=io/tests/test_io.py::test_meshio" %}
+# >   return (px.width/mm.width + px.height/mm.height) * 0.5 * 25.4
+#             ^^^^^^^^^^^^^^^^^
+# E   ZeroDivisionError: division by zero
+{% set deselect_tests = deselect_tests + " --deselect=app/tests/test_backends.py::test_template" %}  # [osx]
+{% set deselect_tests = deselect_tests + " --deselect=util/dpi/tests/test_dpi.py::test_dpi" %}  # [osx]
 test:
   imports:
     - vispy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,67 +1,60 @@
 {% set name = "vispy" %}
-{% set version = "0.14.3" %}
+{% set version = "0.16.1" %}
 
 package:
-  name: vispy
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: vispy-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: efbbb847a908baf7e7169ab9bf296138a39364f367e6cb0a8ec03ad71699d31d
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b93c32c85d08c06ae8f5e3177f9cfd6c495e1745f2120b777830adee5d9c3648
   patches:
     - ctypes_fontconfig.diff
 
 build:
   number: 0
-  script_env:
-    - SETUPTOOLS_SCM_PRETEND_VERSION={{ version }}
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<39]
+  skip: true  # [py<39]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - patch     # [not win]
-    - m2-patch  # [win]
   host:
     - pip
     - python
-    - setuptools >=42
-    - setuptools_scm >=7.1
-    - numpy >=2
-    - fontconfig  # [unix]
-    - cython >=3.0.0
-    - packaging
     - wheel
-
+    - setuptools >=69.4.0
+    - numpy {{ numpy }}
+    - setuptools_scm >=8.1
+    - cython >=3.0.0
   run:
     - python
     - numpy
-    - fontconfig  # [unix]
     - freetype-py
     - hsluv
     - kiwisolver
     - packaging
+  run_constrained:
+    - pyglet >=1.2
 
+# E   ModuleNotFoundError: No module named 'meshio'
+{% set deselect_tests = " --deselect=io/tests/test_io.py::test_meshio" %}
 test:
   imports:
     - vispy
-    # make sure that platform-specific dpi functions can be imported
     - vispy.util.dpi
     - vispy.util.fonts
-  requires:
-   - pip
-  # Only needed for the local UI testing. 
-  #  - pyqt
-  #  - pytest
   commands:
     - pip check
-    # Run the test suite, but requires a display. This is not possible in CI.
-    # - python -c "import vispy; print(vispy.sys_info()); vispy.test()"
+    - pytest --pyargs vispy {{ deselect_tests }}
+  requires:
+   - pip
+   - pytest
+   - pillow
 
 about:
-  home: https://vispy.org/
+  home: https://vispy.org
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt


### PR DESCRIPTION
vispy 0.16.1 

**Destination channel:** Defaults

### Links

- [PKG-11568]
- dev_url:        https://github.com/vispy/vispy/tree/v0.16.1
- conda_forge:    https://github.com/conda-forge/vispy-feedstock
- pypi:           https://pypi.org/project/vispy/0.16.1
- pypi inspector: https://inspector.pypi.io/project/vispy/0.16.1

### Explanation of changes:

- new version number


[PKG-11568]: https://anaconda.atlassian.net/browse/PKG-11568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ